### PR TITLE
Add SPI rating method using logistic regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ python main.py --simulations 1000 --rating poisson
 ```
 
 The `--rating` option accepts `ratio` (default), `historic_ratio`, `poisson`,
-`neg_binom`, `skellam`, `dixon_coles`, `elo`, or `leader_history` to choose how team
+`neg_binom`, `skellam`, `dixon_coles`, `elo`, `spi`, or `leader_history` to choose how team
 strengths are estimated. The `skellam` method fits a regression to goal
 differences. The `historic_ratio` method
 mixes results from the 2024 season with a lower weight. The `elo` method
@@ -27,6 +27,9 @@ strengths based on how often teams led past seasons; configure its behaviour
 with `--leader-history-paths` and `--leader-weight`. When using Elo ratings you
 may set a base home field bonus in rating points via the `home_field_advantage`
 function parameter or the `--elo-home-advantage` CLI option.
+The `spi` rating mimics FiveThirtyEight's approach by fitting a logistic
+regression of match results on the expected goal difference derived from the
+basic attack and defence factors.
 
 The script outputs the estimated chance of winning the title for each team. It then prints the probability of each side finishing in the bottom four and being relegated.
 It also estimates the average final position and points of every club.

--- a/main.py
+++ b/main.py
@@ -28,6 +28,7 @@ def main() -> None:
             "neg_binom",
             "skellam",
             "elo",
+            "spi",
             "leader_history",
         ],
         help="team strength estimation method (use 'historic_ratio' to include past season)",

--- a/src/brasileirao/__init__.py
+++ b/src/brasileirao/__init__.py
@@ -8,6 +8,7 @@ from .simulator import (
     simulate_final_table,
     summary_table,
     estimate_dixon_coles_strengths,
+    estimate_spi_strengths,
     compute_leader_stats,
     estimate_leader_history_strengths,
 )
@@ -20,6 +21,7 @@ __all__ = [
     "simulate_final_table",
     "summary_table",
     "estimate_dixon_coles_strengths",
+    "estimate_spi_strengths",
     "compute_leader_stats",
     "estimate_leader_history_strengths",
 ]

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -286,6 +286,26 @@ def test_simulate_chances_dixon_coles_seed_repeatability():
     assert abs(sum(chances1.values()) - 1.0) < 1e-6
 
 
+def test_simulate_chances_spi_seed_repeatability():
+    df = parse_matches("data/Brasileirao2025A.txt")
+    rng = np.random.default_rng(101)
+    chances1 = simulate_chances(
+        df,
+        iterations=5,
+        rating_method="spi",
+        rng=rng,
+    )
+    rng = np.random.default_rng(101)
+    chances2 = simulate_chances(
+        df,
+        iterations=5,
+        rating_method="spi",
+        rng=rng,
+    )
+    assert chances1 == chances2
+    assert abs(sum(chances1.values()) - 1.0) < 1e-6
+
+
 def test_compute_leader_stats():
     data = [
         {


### PR DESCRIPTION
## Summary
- implement `estimate_spi_strengths` that fits a logistic regression on match results
- expose `spi` rating in API, CLI and `get_strengths`
- document new rating method in README
- test SPI deterministic behaviour

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880692051b4832590cceb9ddf1eb476