### PR TITLE
Add market value strength modifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ may set a base home field bonus in rating points via the `home_field_advantage`
 function parameter or the `--elo-home-advantage` CLI option.
 The `spi` rating mimics FiveThirtyEight's approach by fitting a logistic
 regression of match results on the expected goal difference derived from the
-basic attack and defence factors.
+basic attack and defence factors. Before the regression, each team's attack and
+defence are scaled by its market value from `data/Brasileirao2025A.csv`.  The
+`estimate_spi_strengths` function accepts a ``market_path`` parameter to load a
+different CSV file.
 
 The script outputs the estimated chance of winning the title for each team. It then prints the probability of each side finishing in the bottom four and being relegated.
 It also estimates the average final position and points of every club.

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -108,6 +108,13 @@ def test_estimate_skellam_strengths_deterministic():
     assert first == second
 
 
+def test_estimate_market_strengths_deterministic():
+    df = parse_matches('data/Brasileirao2025A.txt')
+    first = simulator.estimate_market_strengths(df)
+    second = simulator.estimate_market_strengths(df)
+    assert first == second
+
+
 def test_simulate_chances_historic_ratio():
     df = parse_matches('data/Brasileirao2025A.txt')
     chances = simulate_chances(df, iterations=10, rating_method="historic_ratio")


### PR DESCRIPTION
## Summary
- support reading club market value CSV files
- adjust attack/defence with `estimate_market_strengths`
- extend SPI strengths to use market values
- document market-based scaling in README
- test deterministic behaviour of market strength estimates

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68806f4ef0788325aabd4d0a74b3a493