### PR TITLE
Enhance SPI simulations with logistic model

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ regression of match results on the expected goal difference derived from the
 basic attack and defence factors. Before the regression, each team's attack and
 defence are scaled by its market value from `data/Brasileirao2025A.csv`.  The
 `estimate_spi_strengths` function accepts a ``market_path`` parameter to load a
-different CSV file.
+different CSV file.  The fitted intercept and slope are used to convert an
+expected goal difference into win/draw/loss probabilities during the
+simulation.
 
 The script outputs the estimated chance of winning the title for each team. It then prints the probability of each side finishing in the bottom four and being relegated.
 It also estimates the average final position and points of every club.

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -423,6 +423,24 @@ def test_summary_table_deterministic_columns():
     assert {"position", "team", "points", "title", "relegation"}.issubset(table1.columns)
 
 
+def test_simulate_final_table_spi_seed_repeatability():
+    df = parse_matches("data/Brasileirao2025A.txt")
+    rng = np.random.default_rng(202)
+    table1 = simulator.simulate_final_table(df, iterations=5, rating_method="spi", rng=rng)
+    rng = np.random.default_rng(202)
+    table2 = simulator.simulate_final_table(df, iterations=5, rating_method="spi", rng=rng)
+    pd.testing.assert_frame_equal(table1, table2)
+
+
+def test_summary_table_spi_seed_repeatability():
+    df = parse_matches("data/Brasileirao2025A.txt")
+    rng = np.random.default_rng(303)
+    table1 = simulator.summary_table(df, iterations=5, rating_method="spi", rng=rng)
+    rng = np.random.default_rng(303)
+    table2 = simulator.summary_table(df, iterations=5, rating_method="spi", rng=rng)
+    pd.testing.assert_frame_equal(table1, table2)
+
+
 def test_league_table_goal_difference_tiebreak():
     data = [
         {"date": "2025-01-01", "home_team": "A", "away_team": "B", "home_score": 1, "away_score": 2},


### PR DESCRIPTION
## Summary
- return logistic regression coefficients from `estimate_spi_strengths`
- convert expected goal difference to probabilities via `_spi_probs`
- sample SPI results using logistic probabilities
- keep README up-to-date
- test deterministic SPI simulations for final table and summary table

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68813e03aab88325b4369d0bfd307486