### PR TITLE
Add market value configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ argument of `simulate_chances`. The `leader_history` rating method adjusts
 strengths based on how often teams led past seasons; configure its behaviour
 with `--leader-history-paths` and `--leader-weight`. When using Elo ratings you
 may set a base home field bonus in rating points via the `home_field_advantage`
-function parameter or the `--elo-home-advantage` CLI option.
+function parameter or the `--elo-home-advantage` CLI option. When employing the
+`spi` rating you can override the default market values CSV via
+`--market-path`.
 The `spi` rating mimics FiveThirtyEight's approach by fitting a logistic
 regression of match results on the expected goal difference derived from the
 basic attack and defence factors. Before the regression, each team's attack and

--- a/main.py
+++ b/main.py
@@ -63,6 +63,11 @@ def main() -> None:
         default=0.5,
         help="Weight for leader_history influence",
     )
+    parser.add_argument(
+        "--market-path",
+        default="data/Brasileirao2025A.csv",
+        help="CSV with team market values for the spi rating method",
+    )
     args = parser.parse_args()
 
     matches = parse_matches(args.file)
@@ -76,6 +81,7 @@ def main() -> None:
         home_field_advantage=args.elo_home_advantage,
         leader_history_paths=args.leader_history_paths,
         leader_history_weight=args.leader_weight,
+        market_path=args.market_path,
     )
 
     relegation = simulate_relegation_chances(
@@ -87,6 +93,7 @@ def main() -> None:
         home_field_advantage=args.elo_home_advantage,
         leader_history_paths=args.leader_history_paths,
         leader_history_weight=args.leader_weight,
+        market_path=args.market_path,
     )
 
     table_proj = simulate_final_table(
@@ -98,6 +105,7 @@ def main() -> None:
         home_field_advantage=args.elo_home_advantage,
         leader_history_paths=args.leader_history_paths,
         leader_history_weight=args.leader_weight,
+        market_path=args.market_path,
     )
 
     # print("Title chances:")

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -441,6 +441,42 @@ def test_summary_table_spi_seed_repeatability():
     pd.testing.assert_frame_equal(table1, table2)
 
 
+def test_simulate_chances_spi_custom_market_path_changes_results():
+    df = parse_matches("data/Brasileirao2025A.txt")
+    rng = np.random.default_rng(77)
+    base = simulate_chances(df, iterations=20, rating_method="spi", rng=rng)
+    rng = np.random.default_rng(77)
+    custom = simulate_chances(
+        df,
+        iterations=20,
+        rating_method="spi",
+        rng=rng,
+        market_path="data/Brasileirao2024A.csv",
+    )
+    assert base != custom
+
+
+def test_summary_table_spi_custom_market_path_repeatability():
+    df = parse_matches("data/Brasileirao2025A.txt")
+    rng = np.random.default_rng(88)
+    t1 = simulator.summary_table(
+        df,
+        iterations=5,
+        rating_method="spi",
+        rng=rng,
+        market_path="data/Brasileirao2024A.csv",
+    )
+    rng = np.random.default_rng(88)
+    t2 = simulator.summary_table(
+        df,
+        iterations=5,
+        rating_method="spi",
+        rng=rng,
+        market_path="data/Brasileirao2024A.csv",
+    )
+    pd.testing.assert_frame_equal(t1, t2)
+
+
 def test_league_table_goal_difference_tiebreak():
     data = [
         {"date": "2025-01-01", "home_team": "A", "away_team": "B", "home_score": 1, "away_score": 2},


### PR DESCRIPTION
## Summary
- allow overriding the market values CSV throughout the API
- thread the new parameter through all simulation helpers
- expose `--market-path` on the CLI
- document the option
- test SPI simulations with a custom market value file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881431c2de88325b0cb5fb5c17f876f