### PR TITLE
Fix market strength return signature

### DIFF
--- a/src/brasileirao/simulator.py
+++ b/src/brasileirao/simulator.py
@@ -298,8 +298,12 @@ def estimate_market_strengths(
     matches: pd.DataFrame,
     market_path: str | Path = "data/Brasileirao2025A.csv",
     smooth: float = 1.0,
-) -> tuple[dict[str, dict[str, float]], float, float, float, float]:
-    """Estimate strengths adjusted by team market values."""
+) -> tuple[dict[str, dict[str, float]], float, float]:
+    """Estimate strengths adjusted by team market values.
+
+    Returns the attack and defence strengths for each team, the overall
+    average goals per game and the baseline home advantage factor.
+    """
     strengths, avg_goals, home_adv = _estimate_strengths(matches, smooth=smooth)
 
     market_values = load_market_values(market_path)


### PR DESCRIPTION
## Summary
- correct return type for `estimate_market_strengths`
- update docstring to match three returned values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688168cb79c88325a7efbdd9830fed4f