### PR TITLE
Add smooth CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ function exposes an `elo_k` parameter for deterministic runs. Use the
 factor (default `20.0`). Use the `--seed` option to set a random seed and
 reproduce a specific simulation. You can also specify team-specific home
 advantage multipliers by passing a dictionary to the `team_home_advantages`
-argument of `simulate_chances`. The `leader_history` rating method adjusts
+argument of `simulate_chances`. The ratio-based ratings add a smoothing constant
+to goals scored and conceded which can be changed with `--smooth` (default
+`1.0`). The `leader_history` rating method adjusts
 strengths based on how often teams led past seasons; configure its behaviour
 with `--leader-history-paths` and `--leader-weight`. When using Elo ratings you
 may set a base home field bonus in rating points via the `home_field_advantage`

--- a/main.py
+++ b/main.py
@@ -64,6 +64,12 @@ def main() -> None:
         help="Weight for leader_history influence",
     )
     parser.add_argument(
+        "--smooth",
+        type=float,
+        default=1.0,
+        help="Smoothing constant for ratio-based ratings",
+    )
+    parser.add_argument(
         "--market-path",
         default="data/Brasileirao2025A.csv",
         help="CSV with team market values for the spi rating method",
@@ -81,6 +87,7 @@ def main() -> None:
         home_field_advantage=args.elo_home_advantage,
         leader_history_paths=args.leader_history_paths,
         leader_history_weight=args.leader_weight,
+        smooth=args.smooth,
         market_path=args.market_path,
     )
 
@@ -93,6 +100,7 @@ def main() -> None:
         home_field_advantage=args.elo_home_advantage,
         leader_history_paths=args.leader_history_paths,
         leader_history_weight=args.leader_weight,
+        smooth=args.smooth,
         market_path=args.market_path,
     )
 
@@ -105,6 +113,7 @@ def main() -> None:
         home_field_advantage=args.elo_home_advantage,
         leader_history_paths=args.leader_history_paths,
         leader_history_weight=args.leader_weight,
+        smooth=args.smooth,
         market_path=args.market_path,
     )
 

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -164,6 +164,25 @@ def test_elo_k_value_changes_results():
     assert chances_low != chances_high
 
 
+def test_smooth_value_changes_results():
+    df = parse_matches('data/Brasileirao2025A.txt')
+    rng = np.random.default_rng(55)
+    base = simulate_chances(
+        df,
+        iterations=5,
+        rng=rng,
+        smooth=0.5,
+    )
+    rng = np.random.default_rng(55)
+    alt = simulate_chances(
+        df,
+        iterations=5,
+        rng=rng,
+        smooth=2.0,
+    )
+    assert base != alt
+
+
 def test_simulate_chances_neg_binom_seed_repeatability():
     df = parse_matches('data/Brasileirao2025A.txt')
     rng = np.random.default_rng(7)


### PR DESCRIPTION
## Summary
- expose `--smooth` parameter via CLI
- forward `smooth` value to simulation functions
- document the option in README
- test that varying `smooth` affects simulation results

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881aa3c64048325b01b4ee0a0c8f24b