### PR TITLE
Implement SPI default coefficients

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ defence are scaled by its market value from `data/Brasileirao2025A.csv`.  The
 `estimate_spi_strengths` function accepts a ``market_path`` parameter to load a
 different CSV file.  The fitted intercept and slope are used to convert an
 expected goal difference into win/draw/loss probabilities during the
-simulation.
+simulation. When no matches have been played the function returns default
+coefficients of ``-0.180149`` and ``0.228628`` based on the 2023–2024 seasons.
 
 The script outputs the estimated chance of winning the title for each team. It then prints the probability of each side finishing in the bottom four and being relegated.
 It also estimates the average final position and points of every club.

--- a/src/brasileirao/__init__.py
+++ b/src/brasileirao/__init__.py
@@ -11,6 +11,8 @@ from .simulator import (
     estimate_spi_strengths,
     compute_leader_stats,
     estimate_leader_history_strengths,
+    SPI_DEFAULT_INTERCEPT,
+    SPI_DEFAULT_SLOPE,
 )
 from .evaluate import evaluate_methods
 
@@ -26,5 +28,7 @@ __all__ = [
     "compute_leader_stats",
     "estimate_leader_history_strengths",
     "evaluate_methods",
+    "SPI_DEFAULT_INTERCEPT",
+    "SPI_DEFAULT_SLOPE",
 ]
 

--- a/src/brasileirao/simulator.py
+++ b/src/brasileirao/simulator.py
@@ -7,6 +7,10 @@ from pathlib import Path
 from scipy.optimize import minimize
 from scipy.stats import poisson
 
+# Default SPI coefficients derived from the 2023-2024 seasons
+SPI_DEFAULT_INTERCEPT = -0.180149
+SPI_DEFAULT_SLOPE = 0.228628
+
 
 def _parse_date(date_str: str) -> pd.Timestamp:
     """Parse dates from multiple formats."""
@@ -678,7 +682,13 @@ def estimate_spi_strengths(
 
     played = matches.dropna(subset=["home_score", "away_score"])
     if played.empty:
-        return strengths, avg_goals, home_adv, 0.0, 0.0
+        return (
+            strengths,
+            avg_goals,
+            home_adv,
+            SPI_DEFAULT_INTERCEPT,
+            SPI_DEFAULT_SLOPE,
+        )
 
     diffs: list[float] = []
     outcomes: list[int] = []

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -332,6 +332,22 @@ def test_simulate_chances_spi_seed_repeatability():
     assert abs(sum(chances1.values()) - 1.0) < 1e-6
 
 
+def test_estimate_spi_strengths_defaults():
+    data = [
+        {
+            "date": "2025-01-01",
+            "home_team": "A",
+            "away_team": "B",
+            "home_score": np.nan,
+            "away_score": np.nan,
+        }
+    ]
+    df = pd.DataFrame(data)
+    _, _, _, intercept, slope = simulator.estimate_spi_strengths(df)
+    assert intercept == simulator.SPI_DEFAULT_INTERCEPT
+    assert slope == simulator.SPI_DEFAULT_SLOPE
+
+
 def test_compute_leader_stats():
     data = [
         {


### PR DESCRIPTION
## Summary
- add default SPI coefficients from 2023-2024 seasons
- return those defaults when no matches have been played
- export constants via `__init__`
- document behaviour in README
- test default SPI coefficients

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68858bc266c08325968c3e463df462e0