### PR TITLE
Support initial_spi rating in CLI

### DIFF
--- a/main.py
+++ b/main.py
@@ -29,9 +29,10 @@ def main() -> None:
             "skellam",
             "elo",
             "spi",
+            "initial_spi",
             "leader_history",
         ],
-        help="team strength estimation method (use 'historic_ratio' to include past season)",
+        help="team strength estimation method (use 'historic_ratio' to include past season or 'initial_spi' to blend prior ratings)",
     )
     parser.add_argument(
         "--seed",


### PR DESCRIPTION
## Summary
- include `initial_spi` in CLI rating options and help text
- verify the CLI works with `--rating initial_spi`

## Testing
- `python main.py --rating initial_spi --simulations 1 --file data/Brasileirao2024A.txt --market-path data/Brasileirao2024A.csv`
- `pytest -q` *(fails: KeyError in patsy eval)*

------
https://chatgpt.com/codex/tasks/task_e_6885a0f2798c8325b7b50ae4ba2af5ca