### PR TITLE
Add test for team home advantages with empty scores

### DIFF
--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -638,3 +638,12 @@ def test_initial_ratio_differs_from_ratio_without_matches():
     rng = np.random.default_rng(9)
     init_res = simulate_chances(df, iterations=20, rating_method="initial_ratio", rng=rng)
     assert base_res != init_res
+
+
+def test_team_home_advantages_empty():
+    df = parse_matches("data/Brasileirao2025A.txt")
+    adv = simulator._estimate_team_home_advantages(df)
+    teams = pd.unique(df[["home_team", "away_team"]].values.ravel())
+    assert isinstance(adv, dict)
+    assert set(adv.keys()) == set(teams)
+    assert all(v == 1.0 for v in adv.values())


### PR DESCRIPTION
## Summary
- add `test_team_home_advantages_empty` verifying that when no scores are present each team gets a home advantage of 1.0

## Testing
- `pytest -q` *(fails: 4 failed, 13 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6885ad9a8b70832595f7dda0481b10a6