### PR TITLE
Improve season start ratings using market values

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ python main.py --simulations 1000 --rating poisson
 ```
 
 The `--rating` option accepts `ratio` (default), `historic_ratio`, `poisson`,
-`neg_binom`, `skellam`, `dixon_coles`, `elo`, `spi`, `initial_spi`, `initial_ratio`, `initial_points`, or `leader_history` to choose how team
+`neg_binom`, `skellam`, `dixon_coles`, `elo`, `spi`, `initial_spi`, `initial_ratio`, `initial_points`, `initial_points_market`, or `leader_history` to choose how team
 strengths are estimated. The `skellam` method fits a regression to goal
 differences. The `historic_ratio` method
 mixes results from the 2024 season with a lower weight. The `elo` method
@@ -51,6 +51,9 @@ previous season and shrinks them towards the mean. Choose ``initial_ratio`` for
 ``initial_points_strengths`` instead shrinks each club's final points total from
 the prior season before converting the result to attack and defence multipliers.
 Select ``initial_points`` for ``--rating`` to use this approach.
+``initial_points_market_strengths`` blends a club's previous points with its
+market value using a 2/3 to 1/3 ratio. Select ``initial_points_market`` for
+``--rating`` to project a new season based on this mix.
 
 The script outputs the estimated chance of winning the title for each team. It then prints the probability of each side finishing in the bottom four and being relegated.
 It also estimates the average final position and points of every club.

--- a/main.py
+++ b/main.py
@@ -32,9 +32,10 @@ def main() -> None:
             "initial_spi",
             "initial_ratio",
             "initial_points",
+            "initial_points_market",
             "leader_history",
         ],
-        help="team strength estimation method (use 'historic_ratio' to include past season, 'initial_spi', 'initial_ratio', or 'initial_points' to blend prior ratings)",
+        help="team strength estimation method (use 'historic_ratio' to include past season, 'initial_spi', 'initial_ratio', 'initial_points', or 'initial_points_market' to blend prior ratings)",
     )
     parser.add_argument(
         "--seed",


### PR DESCRIPTION
## Summary
- add `initial_points_market_strengths` that mixes prior points with market value
- expose new `initial_points_market` rating method via CLI
- document the option in README
- test weighting logic and deterministic behaviour

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885be96dd5c83258c5f2393cfa9393a