### PR TITLE
Fix return annotation for estimate_spi_strengths

### DIFF
--- a/src/brasileirao/simulator.py
+++ b/src/brasileirao/simulator.py
@@ -679,7 +679,7 @@ def estimate_spi_strengths(
     matches: pd.DataFrame,
     market_path: str | Path = "data/Brasileirao2025A.csv",
     smooth: float = 1.0,
-) -> tuple[dict[str, dict[str, float]], float, float]:
+) -> tuple[dict[str, dict[str, float]], float, float, float, float]:
     """Estimate strengths with a logistic regression on match outcomes.
 
     The function first computes basic attack and defence factors using
@@ -687,8 +687,10 @@ def estimate_spi_strengths(
     for each played match and fits a logistic regression of the home-win
     indicator on that value.  The fitted intercept and slope are returned and
     later used to transform expected goal differences into win/draw/loss
-    probabilities when simulating matches.  The ``market_path`` parameter can be
-    used to supply a custom CSV file with team market values.
+    probabilities when simulating matches.  The function returns five values:
+    the strengths dictionary, average goals per game, baseline home advantage,
+    intercept and slope.  The ``market_path`` parameter can be used to supply a
+    custom CSV file with team market values.
     """
 
     strengths, avg_goals, home_adv = estimate_market_strengths(

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -2,7 +2,12 @@ import os, sys
 import numpy as np
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
 import pandas as pd
-from brasileirao import parse_matches, league_table, simulate_chances
+from brasileirao import (
+    parse_matches,
+    league_table,
+    simulate_chances,
+    estimate_spi_strengths,
+)
 
 
 def test_parse_matches():
@@ -24,3 +29,12 @@ def test_simulate_chances_spi_repeatable():
     rng = np.random.default_rng(123)
     second = simulate_chances(df, iterations=5, rng=rng)
     assert first == second
+
+
+def test_estimate_spi_strengths_returns_five_values():
+    df = parse_matches('data/Brasileirao2025A.txt')
+    result = estimate_spi_strengths(df)
+    assert isinstance(result, tuple)
+    assert len(result) == 5
+    assert isinstance(result[-1], float)
+    assert isinstance(result[-2], float)


### PR DESCRIPTION
## Summary
- expose intercept and slope return types
- document full tuple returned by `estimate_spi_strengths`
- test that the SPI strength estimator returns five values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885ca55d23883259a87e5f6e4330ffd