### PR TITLE
Add auto SPI coefficient helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,19 @@ The helper ``initial_spi_strengths`` can be used at the start of a season to
 shrink each team's previous rating towards the league average following
 ``current = previous × weight + mean × (1 − weight)``.
 
+The ``compute_spi_coeffs`` helper scans the ``data/`` folder for past seasons
+and recalculates the logistic regression intercept and slope.  Seasons can be
+specified via the ``BRASILEIRAO_SEASONS`` environment variable or the
+``--seasons`` argument of the ``spi_coeffs`` module.  When no historical files
+are present the default coefficients above are returned.
+
 To recompute these coefficients yourself run:
 
 ```bash
 PYTHONPATH=src python -m brasileirao.spi_coeffs
 ```
-This command loads the 2023 and 2024 fixtures and prints the fitted
-intercept and slope.
+By default all seasons in ``data/`` are used.  You may pass ``--seasons`` or set
+``BRASILEIRAO_SEASONS`` to limit the years included.
 
 The script outputs the estimated chance of winning the title for each team. It
 then prints the probability of each side finishing in the bottom four and being

--- a/src/brasileirao/__init__.py
+++ b/src/brasileirao/__init__.py
@@ -12,6 +12,7 @@ from .simulator import (
     SPI_DEFAULT_INTERCEPT,
     SPI_DEFAULT_SLOPE,
 )
+from .spi_coeffs import compute_spi_coeffs
 
 __all__ = [
     "parse_matches",
@@ -22,6 +23,7 @@ __all__ = [
     "summary_table",
     "estimate_spi_strengths",
     "initial_spi_strengths",
+    "compute_spi_coeffs",
     "SPI_DEFAULT_INTERCEPT",
     "SPI_DEFAULT_SLOPE",
 ]

--- a/src/brasileirao/spi_coeffs.py
+++ b/src/brasileirao/spi_coeffs.py
@@ -1,10 +1,66 @@
 from __future__ import annotations
 
 import argparse
+import os
 from pathlib import Path
 import pandas as pd
 
-from .simulator import parse_matches, estimate_spi_strengths
+from .simulator import (
+    parse_matches,
+    estimate_spi_strengths,
+    SPI_DEFAULT_INTERCEPT,
+    SPI_DEFAULT_SLOPE,
+)
+
+
+def available_seasons(data_dir: str | Path = "data") -> list[str]:
+    """Return a sorted list of seasons found in ``data_dir``."""
+    seasons: list[str] = []
+    for txt in Path(data_dir).glob("Brasileirao????A.txt"):
+        year = txt.stem[10:14]
+        seasons.append(year)
+    seasons.sort()
+    return seasons
+
+
+def compute_spi_coeffs(
+    seasons: list[str] | None = None,
+    *,
+    data_dir: str | Path = "data",
+    market_path: str | Path = "data/Brasileirao2025A.csv",
+    smooth: float = 1.0,
+) -> tuple[float, float]:
+    """Return fitted intercept and slope from historical seasons.
+
+    ``seasons`` may be provided as a list of years.  If omitted the value of the
+    ``BRASILEIRAO_SEASONS`` environment variable is used.  When that is also
+    unset all seasons found in ``data_dir`` are processed.  If no match files are
+    available the default SPI coefficients are returned.
+    """
+
+    if seasons is None:
+        env = os.getenv("BRASILEIRAO_SEASONS")
+        if env:
+            seasons = [s.strip() for s in env.split(",") if s.strip()]
+    if not seasons:
+        seasons = available_seasons(data_dir)
+
+    frames: list[pd.DataFrame] = []
+    for season in seasons:
+        path = Path(data_dir) / f"Brasileirao{season}A.txt"
+        if path.exists():
+            frames.append(parse_matches(path))
+
+    if not frames:
+        return SPI_DEFAULT_INTERCEPT, SPI_DEFAULT_SLOPE
+
+    matches = pd.concat(frames, ignore_index=True)
+
+    _, _, _, intercept, slope = estimate_spi_strengths(
+        matches, market_path=market_path, smooth=smooth
+    )
+
+    return intercept, slope
 
 
 def main() -> None:
@@ -13,8 +69,13 @@ def main() -> None:
     )
     parser.add_argument(
         "--market-path",
-        default="data/Brasileirao2024A.csv",
+        default="data/Brasileirao2025A.csv",
         help="CSV with team market values",
+    )
+    parser.add_argument(
+        "--seasons",
+        nargs="*",
+        help="Seasons to include (default: all in data/ or $BRASILEIRAO_SEASONS)",
     )
     parser.add_argument(
         "--out",
@@ -24,12 +85,8 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    matches_2023 = parse_matches("data/Brasileirao2023A.txt")
-    matches_2024 = parse_matches("data/Brasileirao2024A.txt")
-    matches = pd.concat([matches_2023, matches_2024], ignore_index=True)
-
-    _, _, _, intercept, slope = estimate_spi_strengths(
-        matches, market_path=args.market_path
+    intercept, slope = compute_spi_coeffs(
+        seasons=args.seasons, market_path=args.market_path
     )
 
     args.out.write(f"{intercept:.6f} {slope:.6f}\n")

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -7,6 +7,9 @@ from brasileirao import (
     league_table,
     simulate_chances,
     estimate_spi_strengths,
+    compute_spi_coeffs,
+    SPI_DEFAULT_INTERCEPT,
+    SPI_DEFAULT_SLOPE,
 )
 
 
@@ -38,3 +41,9 @@ def test_estimate_spi_strengths_returns_five_values():
     assert len(result) == 5
     assert isinstance(result[-1], float)
     assert isinstance(result[-2], float)
+
+
+def test_compute_spi_coeffs_empty_returns_defaults():
+    intercept, slope = compute_spi_coeffs(seasons=[])
+    assert intercept == SPI_DEFAULT_INTERCEPT
+    assert slope == SPI_DEFAULT_SLOPE


### PR DESCRIPTION
## Summary
- expose new `compute_spi_coeffs` helper in library
- compute coefficients from seasons specified by env variable or CLI
- document how to recompute coefficients
- test helper behaviour

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6886679ec97483259039acebeb50a45e