### PR TITLE
Support date-weighted strength estimates

### DIFF
--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -6,6 +6,7 @@ from brasileirao import (
     parse_matches,
     league_table,
     simulate_chances,
+    summary_table,
     estimate_spi_strengths,
     compute_spi_coeffs,
     SPI_DEFAULT_INTERCEPT,
@@ -47,3 +48,17 @@ def test_compute_spi_coeffs_empty_returns_defaults():
     intercept, slope = compute_spi_coeffs(seasons=[])
     assert intercept == SPI_DEFAULT_INTERCEPT
     assert slope == SPI_DEFAULT_SLOPE
+
+
+def test_weighted_strengths_change():
+    df = parse_matches("data/Brasileirao2025A.txt")
+    from brasileirao.simulator import _estimate_strengths
+
+    base, _, _ = _estimate_strengths(df)
+    weighted, _, _ = _estimate_strengths(df, decay_rate=0.01)
+
+    assert base.keys() == weighted.keys()
+    diff = any(
+        not np.isclose(base[t]["attack"], weighted[t]["attack"]) for t in base
+    )
+    assert diff


### PR DESCRIPTION
## Summary
- weigh matches by recency when estimating attack/defence
- propagate optional `decay_rate` parameter through strength estimation helpers
- expose decay weighting in simulation utilities
- test that weighting alters ratings

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688668ec66f483258973cf5b9181a9cd