### PR TITLE
Add decay-rate option for SPI coefficients

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,10 @@ shrink each team's previous rating towards the league average following
 The ``compute_spi_coeffs`` helper scans the ``data/`` folder for past seasons
 and recalculates the logistic regression intercept and slope.  Seasons can be
 specified via the ``BRASILEIRAO_SEASONS`` environment variable or the
-``--seasons`` argument of the ``spi_coeffs`` module.  When no historical files
-are present the default coefficients above are returned.
+``--seasons`` argument of the ``spi_coeffs`` module.  ``--decay-rate`` applies
+exponential weighting to older seasons using ``exp(-decay_rate * age)`` where
+``age`` counts seasons back from the most recent.  When no historical files are
+present the default coefficients above are returned.
 
 To recompute these coefficients yourself run:
 
@@ -40,7 +42,8 @@ To recompute these coefficients yourself run:
 PYTHONPATH=src python -m brasileirao.spi_coeffs
 ```
 By default all seasons in ``data/`` are used.  You may pass ``--seasons`` or set
-``BRASILEIRAO_SEASONS`` to limit the years included.
+``BRASILEIRAO_SEASONS`` to limit the years included.  ``--decay-rate`` controls
+how quickly older seasons lose influence.
 
 The script outputs the estimated chance of winning the title for each team. It
 then prints the probability of each side finishing in the bottom four and being

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -108,3 +108,13 @@ def test_team_home_advantage_changes_results():
     base_pts = base.loc[base.team == "Palmeiras", "points"].iloc[0]
     adv_pts = advantaged.loc[advantaged.team == "Palmeiras", "points"].iloc[0]
     assert base_pts != adv_pts
+
+
+def test_spi_coeffs_decay_changes_values():
+    seasons = ["2023", "2024"]
+    no_decay = compute_spi_coeffs(seasons=seasons, decay_rate=0.0)
+    with_decay = compute_spi_coeffs(seasons=seasons, decay_rate=0.5)
+    assert not (
+        np.isclose(no_decay[0], with_decay[0])
+        and np.isclose(no_decay[1], with_decay[1])
+    )


### PR DESCRIPTION
## Summary
- allow optionally weighting past seasons when computing SPI coefficients
- support per-match weights in `estimate_spi_strengths`
- document decay-rate behaviour in README
- test that decay weighting changes fitted parameters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886851144448325a0154053ed5f286d