### PR TITLE
Add seasons override for initial SPI coefficients

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ The helper ``initial_spi_strengths`` can be used at the start of a season to
 shrink each team's previous rating towards the league average following
 ``current = previous × weight + mean × (1 − weight)``.
 
+Passing a list of ``seasons`` to ``initial_spi_strengths`` replaces the logistic
+regression coefficients with those produced by ``compute_spi_coeffs`` across the
+specified years.  For instance::
+
+    initial_spi_strengths(seasons=["2023", "2024"])
+
 The ``compute_spi_coeffs`` helper scans the ``data/`` folder for past seasons
 and recalculates the logistic regression intercept and slope.  Seasons can be
 specified via the ``BRASILEIRAO_SEASONS`` environment variable or the

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -9,6 +9,7 @@ from brasileirao import (
     simulate_final_table,
     estimate_spi_strengths,
     compute_spi_coeffs,
+    initial_spi_strengths,
     SPI_DEFAULT_INTERCEPT,
     SPI_DEFAULT_SLOPE,
 )
@@ -118,3 +119,18 @@ def test_spi_coeffs_decay_changes_values():
         np.isclose(no_decay[0], with_decay[0])
         and np.isclose(no_decay[1], with_decay[1])
     )
+
+
+def test_initial_spi_strengths_with_seasons():
+    seasons = ["2023", "2024"]
+    expected = compute_spi_coeffs(
+        seasons=seasons, decay_rate=0.0, market_path="data/Brasileirao2024A.csv"
+    )
+    default = initial_spi_strengths()
+    overriden = initial_spi_strengths(seasons=seasons)
+
+    assert not (
+        np.isclose(default[3], expected[0]) and np.isclose(default[4], expected[1])
+    )
+    assert np.isclose(overriden[3], expected[0])
+    assert np.isclose(overriden[4], expected[1])


### PR DESCRIPTION
## Summary
- allow `initial_spi_strengths` to recompute intercept and slope across multiple seasons
- document the new `seasons` option in the README
- test that passing `seasons` uses `compute_spi_coeffs`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68868d56a0248325973d0abe9f8965b5