### PR TITLE
Support multiple past seasons when building initial SPI strengths

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ The helper ``initial_spi_strengths`` can be used at the start of a season to
 shrink each team's previous rating towards the league average following
 ``current = previous × weight + mean × (1 − weight)``.
 
+``past_path`` may also be a sequence of season files or years.  Each season is
+weighted by ``exp(-decay_rate * age)`` where ``age`` counts seasons back from
+the most recent before being combined and shrunk to the league mean.  For
+example::
+
+    initial_spi_strengths(past_path=["2023", "2024"], decay_rate=0.5)
+
 Passing a list of ``seasons`` to ``initial_spi_strengths`` replaces the logistic
 regression coefficients with those produced by ``compute_spi_coeffs`` across the
 specified years.  For instance::

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -134,3 +134,18 @@ def test_initial_spi_strengths_with_seasons():
     )
     assert np.isclose(overriden[3], expected[0])
     assert np.isclose(overriden[4], expected[1])
+
+
+def test_initial_spi_strengths_multiple_seasons_changes_output():
+    single, _, _, _, _ = initial_spi_strengths(
+        past_path="data/Brasileirao2024A.txt"
+    )
+    multi, _, _, _, _ = initial_spi_strengths(
+        past_path=["data/Brasileirao2023A.txt", "data/Brasileirao2024A.txt"]
+    )
+
+    assert "Palmeiras" in single
+    assert "Palmeiras" in multi
+    assert not np.isclose(
+        single["Palmeiras"]["attack"], multi["Palmeiras"]["attack"]
+    )


### PR DESCRIPTION
## Summary
- allow `initial_spi_strengths` to accept a list of season paths/years
- blend past seasons using exponential decay and return weighted strengths
- document the new behaviour in README
- test multi-season functionality

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68869a18b14083258059249a5bfd5e92