### PR TITLE
Support per-season market values for SPI coefficients

### DIFF
--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -149,3 +149,30 @@ def test_initial_spi_strengths_multiple_seasons_changes_output():
     assert not np.isclose(
         single["Palmeiras"]["attack"], multi["Palmeiras"]["attack"]
     )
+
+
+def test_spi_coeffs_uses_season_market_files():
+    seasons = ["2023", "2024"]
+    default = compute_spi_coeffs(seasons=seasons)
+    constant = compute_spi_coeffs(
+        seasons=seasons, market_path="data/Brasileirao2025A.csv"
+    )
+
+    assert not (
+        np.isclose(default[0], constant[0]) and np.isclose(default[1], constant[1])
+    )
+
+
+def test_spi_coeffs_accepts_market_mapping():
+    seasons = ["2023", "2024"]
+    mapping = {
+        "2023": "data/Brasileirao2024A.csv",
+        "2024": "data/Brasileirao2024A.csv",
+    }
+    mapped = compute_spi_coeffs(seasons=seasons, market_path=mapping)
+    constant = compute_spi_coeffs(
+        seasons=seasons, market_path="data/Brasileirao2024A.csv"
+    )
+
+    assert np.isclose(mapped[0], constant[0])
+    assert np.isclose(mapped[1], constant[1])


### PR DESCRIPTION
## Summary
- update `compute_spi_coeffs` to load each season's market CSV
- allow passing a mapping of season to file
- expose this via the `--market-path` CLI option
- test new behaviour for patterns and mappings

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68869df8ee4c832591cecd139d346d47