### PR TITLE
Add rating method CLI option and seasons support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ The simulator uses a FiveThirtyEight-style model (SPI) to estimate team
 strengths. Use the `--market-path` option to specify an alternative CSV with
 team market values. The `--seed` argument sets the random seed for reproducible
 results.
+The `--rating-method` option chooses the algorithm used to rate teams, for
+example `elo` or `poisson` instead of the default `spi`. When using the SPI
+methods, you can pass `--seasons YEAR YEAR ...` to recompute the logistic
+regression coefficients from those past seasons.
 The `spi` rating mimics FiveThirtyEight's approach by fitting a logistic
 regression of match results on the expected goal difference derived from the
 basic attack and defence factors. Before the regression, each team's attack and

--- a/main.py
+++ b/main.py
@@ -32,6 +32,30 @@ def main() -> None:
         default=None,
         help="JSON mapping teams to home advantage multipliers",
     )
+    parser.add_argument(
+        "--rating-method",
+        default="spi",
+        choices=[
+            "spi",
+            "elo",
+            "poisson",
+            "neg_binom",
+            "skellam",
+            "historic_ratio",
+            "dixon_coles",
+            "initial_spi",
+            "initial_ratio",
+            "initial_points",
+            "initial_points_market",
+            "leader_history",
+        ],
+        help="algorithm used to rate teams",
+    )
+    parser.add_argument(
+        "--seasons",
+        nargs="*",
+        help="historical seasons for SPI-based methods",
+    )
     args = parser.parse_args()
 
     matches = parse_matches(args.file)
@@ -46,25 +70,31 @@ def main() -> None:
     chances = simulate_chances(
         matches,
         iterations=args.simulations,
+        rating_method=args.rating_method,
         rng=rng,
         market_path=args.market_path,
         team_home_advantages=team_home,
+        seasons=args.seasons,
     )
 
     relegation = simulate_relegation_chances(
         matches,
         iterations=args.simulations,
+        rating_method=args.rating_method,
         rng=rng,
         market_path=args.market_path,
         team_home_advantages=team_home,
+        seasons=args.seasons,
     )
 
     table_proj = simulate_final_table(
         matches,
         iterations=args.simulations,
+        rating_method=args.rating_method,
         rng=rng,
         market_path=args.market_path,
         team_home_advantages=team_home,
+        seasons=args.seasons,
     )
 
     # print("Title chances:")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,33 @@
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_cli_accepts_rating_method():
+    subprocess.run(
+        [sys.executable, "main.py", "--rating-method", "elo", "--simulations", "1"],
+        check=True,
+        cwd=ROOT,
+        capture_output=True,
+    )
+
+
+def test_cli_accepts_seasons():
+    subprocess.run(
+        [
+            sys.executable,
+            "main.py",
+            "--rating-method",
+            "spi",
+            "--seasons",
+            "2023",
+            "2024",
+            "--simulations",
+            "1",
+        ],
+        check=True,
+        cwd=ROOT,
+        capture_output=True,
+    )


### PR DESCRIPTION
## Summary
- support `--rating-method` and `--seasons` in the CLI
- plumb new arguments through simulator helpers
- document CLI options in the README
- test CLI options via subprocess

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68869fd174208325aa9b8011cf3e533c