### PR TITLE
Compute SPI coeffs when matches absent

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ defence are scaled by its market value from `data/Brasileirao2025A.csv`.  The
 `estimate_spi_strengths` function accepts a ``market_path`` parameter to load a
 different CSV file.  The fitted intercept and slope are used to convert an
 expected goal difference into win/draw/loss probabilities during the
-simulation. When no matches have been played the function returns default
-coefficients of ``-0.180149`` and ``0.228628`` based on the 2023–2024 seasons.
+simulation. When no matches have been played the intercept and slope are
+automatically derived from the available seasons using ``compute_spi_coeffs``
+instead of returning the hard-coded ``-0.180149`` and ``0.228628`` defaults.
 The helper ``initial_spi_strengths`` can be used at the start of a season to
 shrink each team's previous rating towards the league average following
 ``current = previous × weight + mean × (1 − weight)``.

--- a/src/brasileirao/simulator.py
+++ b/src/brasileirao/simulator.py
@@ -846,12 +846,15 @@ def estimate_spi_strengths(
 
     played = matches.dropna(subset=["home_score", "away_score"]).sort_values("date")
     if played.empty:
+        from .spi_coeffs import compute_spi_coeffs
+
+        intercept, slope = compute_spi_coeffs()
         return (
             strengths,
             avg_goals,
             home_adv,
-            SPI_DEFAULT_INTERCEPT,
-            SPI_DEFAULT_SLOPE,
+            intercept,
+            slope,
         )
 
     diffs: list[float] = []


### PR DESCRIPTION
## Summary
- detect when `estimate_spi_strengths` has no played matches
- fetch coefficients from `compute_spi_coeffs` instead of using defaults
- document dynamic coefficient behaviour in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886a2e5a0a483259a265b25e8931cf8