### PR TITLE
Clarify default SPI behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ pip install -r requirements.txt
 python main.py --simulations 1000
 ```
 
+By default the command line uses the `spi` rating method. The logistic
+regression intercept and slope are recalculated from the historical season
+files found in `data/` so the predictions reflect recent results. For a new
+campaign without any completed fixtures you can initialise the ratings using
+``initial_spi_strengths``.
+
 The simulator uses a FiveThirtyEight-style model (SPI) to estimate team
 strengths. Use the `--market-path` option to specify an alternative CSV with
 team market values. The `--seed` argument sets the random seed for reproducible

--- a/main.py
+++ b/main.py
@@ -13,7 +13,15 @@ from brasileirao import (
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Simulate Brasileirão 2025 title odds")
+    parser = argparse.ArgumentParser(
+        description=(
+            "Simulate Brasileirão 2025 title odds. "
+            "The simulator uses FiveThirtyEight's SPI ratings by default and "
+            "recomputes the logistic regression coefficients from the "
+            "historical seasons in 'data/'. For a new campaign seed the ratings "
+            "with `initial_spi_strengths`."
+        )
+    )
     parser.add_argument("--file", default="data/Brasileirao2025A.txt", help="fixture file path")
     parser.add_argument("--simulations", type=int, default=1000, help="number of simulation runs")
     parser.add_argument(
@@ -49,7 +57,11 @@ def main() -> None:
             "initial_points_market",
             "leader_history",
         ],
-        help="algorithm used to rate teams",
+        help=(
+            "algorithm used to rate teams (default: spi). "
+            "SPI-based methods recompute the coefficients from the historical "
+            "data."
+        ),
     )
     parser.add_argument(
         "--seasons",


### PR DESCRIPTION
## Summary
- highlight that the simulator defaults to SPI ratings
- note that coefficients are recalculated from historical data
- mention `initial_spi_strengths` as the best starting point for a new season
- mirror this information in the CLI help text

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886a5ac4d648325a162293623405d63