### PR TITLE
Add logistic decay option for SPI regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ The simulator uses a FiveThirtyEight-style model (SPI) to estimate team
 strengths. Use the `--market-path` option to specify an alternative CSV with
 team market values. The `--seed` argument sets the random seed for reproducible
 results.
+Use `--logistic-decay` to weight recent games more heavily when fitting the
+SPI logistic regression. A fixture played `d` days before the most recent one
+receives weight `exp(-logistic_decay * d)`.
 The `--rating-method` option chooses the algorithm used to rate teams, for
 example `elo` or `poisson` instead of the default `spi`. When using the SPI
 methods, you can pass `--seasons YEAR YEAR ...` to recompute the logistic
@@ -68,6 +71,8 @@ PYTHONPATH=src python -m brasileirao.spi_coeffs
 By default all seasons in ``data/`` are used.  You may pass ``--seasons`` or set
 ``BRASILEIRAO_SEASONS`` to limit the years included.  ``--decay-rate`` controls
 how quickly older seasons lose influence.
+``logistic_decay`` can be set in the simulation functions to apply a similar
+exponential weight to recent fixtures when fitting the SPI logistic regression.
 
 The script outputs the estimated chance of winning the title for each team. It
 then prints the probability of each side finishing in the bottom four and being

--- a/main.py
+++ b/main.py
@@ -68,6 +68,15 @@ def main() -> None:
         nargs="*",
         help="historical seasons for SPI-based methods",
     )
+    parser.add_argument(
+        "--logistic-decay",
+        type=float,
+        default=None,
+        help=(
+            "exponential weight for recent matches when fitting the SPI "
+            "logistic regression"
+        ),
+    )
     args = parser.parse_args()
 
     matches = parse_matches(args.file)
@@ -86,6 +95,7 @@ def main() -> None:
         rng=rng,
         market_path=args.market_path,
         team_home_advantages=team_home,
+        logistic_decay=args.logistic_decay,
         seasons=args.seasons,
     )
 
@@ -96,6 +106,7 @@ def main() -> None:
         rng=rng,
         market_path=args.market_path,
         team_home_advantages=team_home,
+        logistic_decay=args.logistic_decay,
         seasons=args.seasons,
     )
 
@@ -106,6 +117,7 @@ def main() -> None:
         rng=rng,
         market_path=args.market_path,
         team_home_advantages=team_home,
+        logistic_decay=args.logistic_decay,
         seasons=args.seasons,
     )
 

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -176,3 +176,13 @@ def test_spi_coeffs_accepts_market_mapping():
 
     assert np.isclose(mapped[0], constant[0])
     assert np.isclose(mapped[1], constant[1])
+
+
+def test_logistic_decay_changes_spi_coeffs():
+    df = parse_matches("data/Brasileirao2025A.txt")
+    base = estimate_spi_strengths(df)
+    decayed = estimate_spi_strengths(df, logistic_decay=0.01)
+
+    assert not (
+        np.isclose(base[3], decayed[3]) and np.isclose(base[4], decayed[4])
+    )


### PR DESCRIPTION
## Summary
- add logistic decay weighting for SPI regression
- forward parameter through simulation helpers and CLI
- document new option in README and CLI help
- test that logistic decay affects SPI coefficients

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886b14b7f0c8325b77ea5172cdef520