### PR TITLE
Add logistic_decay to SPI coefficients

### DIFF
--- a/src/brasileirao/spi_coeffs.py
+++ b/src/brasileirao/spi_coeffs.py
@@ -34,6 +34,7 @@ def compute_spi_coeffs(
     ),
     smooth: float = 1.0,
     decay_rate: float = 0.0,
+    logistic_decay: float | None = None,
 ) -> tuple[float, float]:
     """Return fitted intercept and slope from historical seasons.
 
@@ -46,8 +47,9 @@ def compute_spi_coeffs(
     may be a custom pattern containing ``{season}`` or a mapping from season to
     CSV path. All matches from the selected seasons are merged into a single
     DataFrame and passed once to :func:`estimate_spi_strengths` using the
-    computed weights. If no match files are available the default SPI
-    coefficients are returned.
+    computed weights. ``logistic_decay`` applies an exponential weight to
+    recent fixtures when fitting the logistic regression. If no match files are
+    available the default SPI coefficients are returned.
     """
 
     if seasons is None:
@@ -97,6 +99,7 @@ def compute_spi_coeffs(
         all_matches,
         market_path=csv_path,
         smooth=smooth,
+        logistic_decay=logistic_decay,
         match_weights=weights,
     )
 
@@ -128,6 +131,15 @@ def main() -> None:
         help="Exponential decay rate for historical seasons",
     )
     parser.add_argument(
+        "--logistic-decay",
+        type=float,
+        default=None,
+        help=(
+            "exponential weight for recent matches when fitting the logistic"
+            " regression"
+        ),
+    )
+    parser.add_argument(
         "--out",
         type=argparse.FileType("w"),
         default="-",
@@ -152,6 +164,7 @@ def main() -> None:
         seasons=args.seasons,
         market_path=market,
         decay_rate=args.decay_rate,
+        logistic_decay=args.logistic_decay,
     )
 
     args.out.write(f"{intercept:.6f} {slope:.6f}\n")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 import subprocess
 import sys
+import os
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -29,5 +30,23 @@ def test_cli_accepts_seasons():
         ],
         check=True,
         cwd=ROOT,
+        capture_output=True,
+    )
+
+
+def test_spi_coeffs_cli_accepts_logistic_decay():
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(ROOT / "src")
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "brasileirao.spi_coeffs",
+            "--logistic-decay",
+            "0.01",
+        ],
+        check=True,
+        cwd=ROOT,
+        env=env,
         capture_output=True,
     )

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -213,3 +213,13 @@ def test_logistic_decay_changes_spi_coeffs():
     assert not (
         np.isclose(base[3], decayed[3]) and np.isclose(base[4], decayed[4])
     )
+
+
+def test_compute_spi_coeffs_logistic_decay_changes_values():
+    seasons = ["2023", "2024"]
+    base = compute_spi_coeffs(seasons=seasons, logistic_decay=None)
+    decayed = compute_spi_coeffs(seasons=seasons, logistic_decay=0.01)
+
+    assert not (
+        np.isclose(base[0], decayed[0]) and np.isclose(base[1], decayed[1])
+    )


### PR DESCRIPTION
## Summary
- support `logistic_decay` when computing SPI coefficients
- expose `--logistic-decay` in the spi_coeffs CLI
- test compute_spi_coeffs with logistic decay
- test cli module accepts the new option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886bccddfcc83259c37af8d04fee342