### PR TITLE
Fix default rating_method in docstring

### DIFF
--- a/src/brasileirao/simulator.py
+++ b/src/brasileirao/simulator.py
@@ -1387,7 +1387,7 @@ def simulate_chances(
         DataFrame containing all fixtures. Played games must have scores.
     iterations : int, default 1000
         Number of simulation runs.
-    rating_method : str, default "ratio"
+    rating_method : str, default "spi"
         Method used to estimate team strengths.
     rng : np.random.Generator | None, optional
         Random number generator to use. A new generator is created when ``None``.


### PR DESCRIPTION
## Summary
- correct `simulate_chances` parameter docs to show `rating_method="spi"`

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6886c2cbb96083259b420066f8cafd35