### PR TITLE
Add decay-rate option

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Install dependencies from `requirements.txt` and run the simulator:
 
 ```bash
 pip install -r requirements.txt
-python main.py --simulations 1000
+python main.py --simulations 1000 --decay-rate 0.01
 ```
 
 By default the command line uses the `spi` rating method. The logistic
@@ -24,6 +24,8 @@ results.
 Use `--logistic-decay` to weight recent games more heavily when fitting the
 SPI logistic regression. A fixture played `d` days before the most recent one
 receives weight `exp(-logistic_decay * d)`.
+Use `--decay-rate` to exponentially downweight older matches when estimating
+strengths, applying weight `exp(-decay_rate * days_since)`.
 The `--rating-method` option chooses the algorithm used to rate teams, for
 example `elo` or `poisson` instead of the default `spi`. When using the SPI
 methods, you can pass `--seasons YEAR YEAR ...` to recompute the logistic

--- a/main.py
+++ b/main.py
@@ -77,6 +77,14 @@ def main() -> None:
             "logistic regression"
         ),
     )
+    parser.add_argument(
+        "--decay-rate",
+        type=float,
+        default=None,
+        help=(
+            "exponential weight for older matches when estimating strengths"
+        ),
+    )
     args = parser.parse_args()
 
     matches = parse_matches(args.file)
@@ -96,6 +104,7 @@ def main() -> None:
         market_path=args.market_path,
         team_home_advantages=team_home,
         logistic_decay=args.logistic_decay,
+        decay_rate=args.decay_rate,
         seasons=args.seasons,
     )
 
@@ -107,6 +116,7 @@ def main() -> None:
         market_path=args.market_path,
         team_home_advantages=team_home,
         logistic_decay=args.logistic_decay,
+        decay_rate=args.decay_rate,
         seasons=args.seasons,
     )
 
@@ -118,6 +128,7 @@ def main() -> None:
         market_path=args.market_path,
         team_home_advantages=team_home,
         logistic_decay=args.logistic_decay,
+        decay_rate=args.decay_rate,
         seasons=args.seasons,
     )
 


### PR DESCRIPTION
## Summary
- add `--decay-rate` CLI argument to `main.py`
- pass decay rate through to simulation functions
- document the new option in README usage instructions

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886c839f4ec8325bd7779d641841213