### PR TITLE
Set default logistic decay

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ team market values. The `--seed` argument sets the random seed for reproducible
 results.
 Use `--logistic-decay` to weight recent games more heavily when fitting the
 SPI logistic regression. A fixture played `d` days before the most recent one
-receives weight `exp(-logistic_decay * d)`.
+receives weight `exp(-logistic_decay * d)`. If omitted the decay defaults to
+`0.007`.
 Use `--decay-rate` to exponentially downweight older matches when estimating
 strengths, applying weight `exp(-decay_rate * days_since)`.
 The `--rating-method` option chooses the algorithm used to rate teams, for
@@ -75,6 +76,7 @@ By default all seasons in ``data/`` are used.  You may pass ``--seasons`` or set
 how quickly older seasons lose influence.
 ``logistic_decay`` can be set in the simulation functions to apply a similar
 exponential weight to recent fixtures when fitting the SPI logistic regression.
+When omitted the simulator uses a default of ``0.007``.
 
 The script outputs the estimated chance of winning the title for each team. It
 then prints the probability of each side finishing in the bottom four and being

--- a/main.py
+++ b/main.py
@@ -71,10 +71,10 @@ def main() -> None:
     parser.add_argument(
         "--logistic-decay",
         type=float,
-        default=None,
+        default=0.007,
         help=(
             "exponential weight for recent matches when fitting the SPI "
-            "logistic regression"
+            "logistic regression (default: 0.007)"
         ),
     )
     parser.add_argument(

--- a/src/brasileirao/simulator.py
+++ b/src/brasileirao/simulator.py
@@ -820,7 +820,7 @@ def estimate_spi_strengths(
     market_path: str | Path = "data/Brasileirao2025A.csv",
     smooth: float = 1.0,
     decay_rate: float | None = None,
-    logistic_decay: float | None = None,
+    logistic_decay: float | None = 0.007,
     match_weights: pd.Series | None = None,
     *,
     K: float = 0.05,
@@ -838,7 +838,8 @@ def estimate_spi_strengths(
     custom CSV file with team market values. ``logistic_decay`` optionally
     applies exponential weighting to recent fixtures when fitting the logistic
     regression: a match ``d`` days before the latest carries weight
-    ``exp(-logistic_decay * d)``. ``match_weights`` may directly provide a
+    ``exp(-logistic_decay * d)``. If omitted the decay defaults to ``0.007``.
+    ``match_weights`` may directly provide a
     sequence of weights for the played matches when fitting the regression.
     ``K`` controls the magnitude of rating updates after each played match.
     """

--- a/src/brasileirao/spi_coeffs.py
+++ b/src/brasileirao/spi_coeffs.py
@@ -34,7 +34,7 @@ def compute_spi_coeffs(
     ),
     smooth: float = 1.0,
     decay_rate: float = 0.0,
-    logistic_decay: float | None = None,
+    logistic_decay: float | None = 0.007,
 ) -> tuple[float, float]:
     """Return fitted intercept and slope from historical seasons.
 
@@ -48,7 +48,8 @@ def compute_spi_coeffs(
     CSV path. All matches from the selected seasons are merged into a single
     DataFrame and passed once to :func:`estimate_spi_strengths` using the
     computed weights. ``logistic_decay`` applies an exponential weight to
-    recent fixtures when fitting the logistic regression. If no match files are
+    recent fixtures when fitting the logistic regression. The default decay
+    rate is ``0.007``. If no match files are
     available the default SPI coefficients are returned.
     """
 

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -114,8 +114,8 @@ def test_team_home_advantage_changes_results():
 
 def test_spi_coeffs_decay_changes_values():
     seasons = ["2023", "2024"]
-    no_decay = compute_spi_coeffs(seasons=seasons, decay_rate=0.0)
-    with_decay = compute_spi_coeffs(seasons=seasons, decay_rate=0.5)
+    no_decay = compute_spi_coeffs(seasons=seasons, decay_rate=0.0, logistic_decay=None)
+    with_decay = compute_spi_coeffs(seasons=seasons, decay_rate=0.5, logistic_decay=None)
     assert not (
         np.isclose(no_decay[0], with_decay[0])
         and np.isclose(no_decay[1], with_decay[1])


### PR DESCRIPTION
## Summary
- default `logistic_decay` in `estimate_spi_strengths` to `0.007`
- use the same default in `compute_spi_coeffs`
- expose the default via `--logistic-decay` CLI option
- document new behaviour in README
- update test to explicitly disable decay

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886cc37e47c83259111195dba473d5b