### PR TITLE
Combine logistic and match weights

### DIFF
--- a/src/brasileirao/simulator.py
+++ b/src/brasileirao/simulator.py
@@ -840,7 +840,9 @@ def estimate_spi_strengths(
     regression: a match ``d`` days before the latest carries weight
     ``exp(-logistic_decay * d)``. If omitted the decay defaults to ``0.007``.
     ``match_weights`` may directly provide a
-    sequence of weights for the played matches when fitting the regression.
+    sequence of weights for the played matches when fitting the regression. If
+    both ``logistic_decay`` and ``match_weights`` are given the resulting
+    weights are multiplied.
     ``K`` controls the magnitude of rating updates after each played match.
     """
 
@@ -888,7 +890,12 @@ def estimate_spi_strengths(
 
     exog = sm.add_constant(pd.Series(diffs, name="diff"))
     weights = None
-    if logistic_weights is not None:
+    if logistic_weights is not None and match_weights is not None:
+        weights = pd.Series(
+            logistic_weights.values * match_weights.loc[played.index].values,
+            index=exog.index,
+        )
+    elif logistic_weights is not None:
         weights = pd.Series(logistic_weights.values, index=exog.index)
     elif match_weights is not None:
         weights = pd.Series(match_weights.loc[played.index], index=exog.index)

--- a/src/brasileirao/spi_coeffs.py
+++ b/src/brasileirao/spi_coeffs.py
@@ -48,8 +48,9 @@ def compute_spi_coeffs(
     CSV path. All matches from the selected seasons are merged into a single
     DataFrame and passed once to :func:`estimate_spi_strengths` using the
     computed weights. ``logistic_decay`` applies an exponential weight to
-    recent fixtures when fitting the logistic regression. The default decay
-    rate is ``0.007``. If no match files are
+    recent fixtures when fitting the logistic regression. When both logistic
+    weighting and the computed match weights are present they are multiplied.
+    The default decay rate is ``0.007``. If no match files are
     available the default SPI coefficients are returned.
     """
 

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -223,3 +223,23 @@ def test_compute_spi_coeffs_logistic_decay_changes_values():
     assert not (
         np.isclose(base[0], decayed[0]) and np.isclose(base[1], decayed[1])
     )
+
+
+def test_logistic_and_match_weight_combination():
+    df = parse_matches("data/Brasileirao2025A.txt")
+    weights = pd.Series(np.linspace(1.0, 2.0, len(df)), index=df.index)
+
+    logistic = estimate_spi_strengths(df, logistic_decay=0.01)
+    manual = estimate_spi_strengths(df, logistic_decay=None, match_weights=weights)
+    combined = estimate_spi_strengths(
+        df, logistic_decay=0.01, match_weights=weights
+    )
+
+    assert not (
+        np.isclose(combined[3], logistic[3])
+        and np.isclose(combined[4], logistic[4])
+    )
+    assert not (
+        np.isclose(combined[3], manual[3])
+        and np.isclose(combined[4], manual[4])
+    )


### PR DESCRIPTION
## Summary
- combine logistic and match weights in `estimate_spi_strengths`
- document the multiplicative weighting
- test that logistic and manual weights interact

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886ce90bf8483258b03d7e7f3e57360