### PR TITLE
Document logistic decay defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ By default all seasons in ``data/`` are used.  You may pass ``--seasons`` or set
 how quickly older seasons lose influence.
 ``logistic_decay`` can be set in the simulation functions to apply a similar
 exponential weight to recent fixtures when fitting the SPI logistic regression.
-When omitted the simulator uses a default of ``0.007``.
+When omitted the simulator uses a default of ``0.007`` and the API functions
+share the same fallback.
 
 The script outputs the estimated chance of winning the title for each team. It
 then prints the probability of each side finishing in the bottom four and being

--- a/src/brasileirao/simulator.py
+++ b/src/brasileirao/simulator.py
@@ -834,7 +834,8 @@ def estimate_spi_strengths(
     custom CSV file with team market values. ``logistic_decay`` optionally
     applies exponential weighting to recent fixtures when fitting the logistic
     regression: a match ``d`` days before the latest carries weight
-    ``exp(-logistic_decay * d)``. If omitted the decay defaults to ``0.007``.
+    ``exp(-logistic_decay * d)``. If omitted, the logistic decay defaults to
+    ``0.007``.
     ``match_weights`` may directly provide a
     sequence of weights for the played matches when fitting the regression. If
     both ``logistic_decay`` and ``match_weights`` are given the resulting
@@ -1212,7 +1213,7 @@ def get_strengths(
     coefficients when ``rating_method`` is ``"spi"`` or ``"initial_spi"``.
     ``logistic_decay`` weighs recent results more heavily in the SPI logistic
     regression using ``exp(-logistic_decay * days_since_latest)``. When omitted
-    the decay defaults to ``0.007``.
+    the logistic decay defaults to ``0.007``.
     """
 
     extra_param = 0.0

--- a/src/brasileirao/spi_coeffs.py
+++ b/src/brasileirao/spi_coeffs.py
@@ -50,7 +50,7 @@ def compute_spi_coeffs(
     computed weights. ``logistic_decay`` applies an exponential weight to
     recent fixtures when fitting the logistic regression. When both logistic
     weighting and the computed match weights are present they are multiplied.
-    The default decay rate is ``0.007``. If no match files are
+    The logistic decay rate defaults to ``0.007``. If no match files are
     available the default SPI coefficients are returned.
     """
 


### PR DESCRIPTION
## Summary
- note in README that API also defaults to 0.007
- clarify logistic decay defaults in the compute_spi_coeffs and simulator docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886e482b78c8325ab0de22bc5709a03