### PR TITLE
Filter incomplete seasons

### DIFF
--- a/src/brasileirao/spi_coeffs.py
+++ b/src/brasileirao/spi_coeffs.py
@@ -15,10 +15,20 @@ from .simulator import (
 )
 
 
-def available_seasons(data_dir: str | pathlib.Path = "data") -> list[str]:
+def season_complete(path: pathlib.Path) -> bool:
+    """Return ``True`` if all fixtures in ``path`` have final scores."""
+    df = parse_matches(path)
+    return not (df["home_score"].isna().any() or df["away_score"].isna().any())
+
+
+def available_seasons(
+    data_dir: str | pathlib.Path = "data", *, only_complete: bool = False
+) -> list[str]:
     """Return a sorted list of seasons found in ``data_dir``."""
     seasons: list[str] = []
     for txt in pathlib.Path(data_dir).glob("Brasileirao????A.txt"):
+        if only_complete and not season_complete(txt):
+            continue
         year = txt.stem[11:15]
         seasons.append(year)
     seasons.sort()
@@ -61,7 +71,7 @@ def compute_spi_coeffs(
     elif len(seasons) == 0:
         return SPI_DEFAULT_INTERCEPT, SPI_DEFAULT_SLOPE
     if not seasons:
-        seasons = available_seasons(data_dir)
+        seasons = available_seasons(data_dir, only_complete=True)
 
     if isinstance(market_path, Mapping):
         market_map = {str(k): str(v) for k, v in market_path.items()}

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -20,6 +20,7 @@ from brasileirao.simulator import (
     estimate_market_strengths,
     compute_leader_stats,
 )
+from brasileirao.spi_coeffs import available_seasons
 
 
 def test_parse_matches():
@@ -64,6 +65,14 @@ def test_compute_spi_coeffs_empty_returns_defaults():
     intercept, slope = compute_spi_coeffs(seasons=[])
     assert intercept == SPI_DEFAULT_INTERCEPT
     assert slope == SPI_DEFAULT_SLOPE
+
+
+def test_compute_spi_coeffs_filters_incomplete_seasons():
+    seasons = available_seasons(only_complete=True)
+    explicit = compute_spi_coeffs(seasons=seasons)
+    default = compute_spi_coeffs()
+    assert np.isclose(explicit[0], default[0])
+    assert np.isclose(explicit[1], default[1])
 
 
 def test_weighted_strengths_change():


### PR DESCRIPTION
## Summary
- skip seasons without final scores when deriving SPI coefficients
- add unit test ensuring compute_spi_coeffs() ignores incomplete data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886fa28397483259c4fd54cdda7d8f3