### PR TITLE
Apply shrinkage to team home advantage

### DIFF
--- a/src/brasileirao/simulator.py
+++ b/src/brasileirao/simulator.py
@@ -303,12 +303,15 @@ def _estimate_strengths(
 
 
 def _estimate_team_home_advantages(
-    matches: pd.DataFrame, factors: dict[str, float] | None = None
+    matches: pd.DataFrame,
+    factors: dict[str, float] | None = None,
+    shrink_weight: float = 0.67,
 ) -> dict[str, float]:
     """Return relative home advantage factors for each team.
 
     When ``factors`` is supplied the dictionary is updated in-place so the
-    caller can maintain values across seasons.
+    caller can maintain values across seasons. ``shrink_weight`` controls how
+    strongly the raw estimates are pulled toward ``1.0``.
     """
     played = matches.dropna(subset=["home_score", "away_score"])
 
@@ -334,6 +337,7 @@ def _estimate_team_home_advantages(
             results[t] = 1.0
         else:
             results[t] = float((home_gpg / away_gpg) / baseline)
+        results[t] = results[t] * shrink_weight + (1 - shrink_weight)
 
     if factors is not None:
         for t in results:
@@ -1434,9 +1438,9 @@ def simulate_chances(
         rng = np.random.default_rng()
 
     if team_home_advantages is None:
-        team_home_advantages = _estimate_team_home_advantages(matches)
+        team_home_advantages = _estimate_team_home_advantages(matches, shrink_weight=0.67)
     else:
-        merged = _estimate_team_home_advantages(matches)
+        merged = _estimate_team_home_advantages(matches, shrink_weight=0.67)
         merged.update(team_home_advantages)
         team_home_advantages = merged
 
@@ -1521,9 +1525,9 @@ def simulate_relegation_chances(
         rng = np.random.default_rng()
 
     if team_home_advantages is None:
-        team_home_advantages = _estimate_team_home_advantages(matches)
+        team_home_advantages = _estimate_team_home_advantages(matches, shrink_weight=0.67)
     else:
-        merged = _estimate_team_home_advantages(matches)
+        merged = _estimate_team_home_advantages(matches, shrink_weight=0.67)
         merged.update(team_home_advantages)
         team_home_advantages = merged
 
@@ -1608,9 +1612,9 @@ def simulate_final_table(
         rng = np.random.default_rng()
 
     if team_home_advantages is None:
-        team_home_advantages = _estimate_team_home_advantages(matches)
+        team_home_advantages = _estimate_team_home_advantages(matches, shrink_weight=0.67)
     else:
-        merged = _estimate_team_home_advantages(matches)
+        merged = _estimate_team_home_advantages(matches, shrink_weight=0.67)
         merged.update(team_home_advantages)
         team_home_advantages = merged
 

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -134,6 +134,18 @@ def test_team_home_advantage_changes_results():
     assert base_pts != adv_pts
 
 
+def test_home_advantage_shrinkage_modifies_values():
+    df = parse_matches("data/Brasileirao2025A.txt")
+    from brasileirao.simulator import _estimate_team_home_advantages
+
+    raw = _estimate_team_home_advantages(df, shrink_weight=1.0)
+    shrunk = _estimate_team_home_advantages(df)
+
+    assert raw.keys() == shrunk.keys()
+    changed = any(not np.isclose(raw[t], shrunk[t]) for t in raw)
+    assert changed
+
+
 def test_spi_coeffs_decay_changes_values():
     seasons = ["2023", "2024"]
     no_decay = compute_spi_coeffs(seasons=seasons, decay_rate=0.0, logistic_decay=None)


### PR DESCRIPTION
## Summary
- estimate team-specific home advantage with optional shrinkage
- call the estimator with shrinkage during simulations
- test that shrinking alters the estimated advantages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886fc44cb4083258e7c7f3f32223096