### PR TITLE
Update SPI coefficients

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ different CSV file.  The fitted intercept and slope are used to convert an
 expected goal difference into win/draw/loss probabilities during the
 simulation. When no matches have been played the intercept and slope are
 automatically derived from the available seasons using ``compute_spi_coeffs``
-instead of returning the hard-coded ``-0.180149`` and ``0.228628`` defaults.
+instead of returning the hard-coded ``-0.309255`` and ``0.425492`` defaults.
 The helper ``initial_spi_strengths`` can be used at the start of a season to
 shrink each team's previous rating towards the league average following
 ``current = previous × weight + mean × (1 − weight)``.

--- a/src/brasileirao/simulator.py
+++ b/src/brasileirao/simulator.py
@@ -8,9 +8,9 @@ from collections.abc import Sequence
 from scipy.optimize import minimize
 from scipy.stats import poisson
 
-# Default SPI coefficients derived from the 2023-2024 seasons
-SPI_DEFAULT_INTERCEPT = -0.180149
-SPI_DEFAULT_SLOPE = 0.228628
+# Default SPI coefficients derived from the 2022-2025 seasons
+SPI_DEFAULT_INTERCEPT = -0.309255
+SPI_DEFAULT_SLOPE = 0.425492
 
 
 def _parse_date(date_str: str) -> pd.Timestamp:


### PR DESCRIPTION
## Summary
- recompute default SPI intercept/slope using all seasons
- update README to document new defaults

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886fe13791c8325b6f19e9b97e1f472