### PR TITLE
Add SPI column to summary output

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ When omitted the simulator uses a default of ``0.007``.
 The script outputs the estimated chance of winning the title for each team. It
 then prints the probability of each side finishing in the bottom four and being
 relegated. It also estimates the average final position and points of every club.
+Each team is listed with an SPI rating derived from its attack and defence
+strengths.
 
 ## Tie-break Rules
 

--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ from brasileirao import (
     simulate_relegation_chances,
     simulate_final_table,
 )
+from brasileirao.simulator import get_strengths
 
 
 def main() -> None:
@@ -151,14 +152,27 @@ def main() -> None:
     summary["position"] = range(1, len(summary) + 1)
     summary["points"] = summary["points"].round().astype(int)
 
+    strengths, _avg, _ha, _ = get_strengths(
+        matches,
+        args.rating_method,
+        market_path=args.market_path,
+        decay_rate=args.decay_rate,
+        logistic_decay=args.logistic_decay,
+    )
+    spi = {
+        t: float(30 * np.log10(max(s["attack"] / s["defense"], 1e-6)) + 75)
+        for t, s in strengths.items()
+    }
+    summary["spi"] = summary["team"].map(spi)
+
     TITLE_W = 7
     REL_W = 10
-    print(f"{'Pos':>3}  {'Team':15s} {'Points':>6} {'Title':^{TITLE_W}} {'Relegation':^{REL_W}}")
+    print(f"{'Pos':>3}  {'Team':15s} {'SPI':>6} {'Points':>6} {'Title':^{TITLE_W}} {'Relegation':^{REL_W}}")
     for _, row in summary.iterrows():
         title = f"{row['title']:.2%}"
         releg = f"{row['relegation']:.2%}"
         print(
-            f"{row['position']:>2d}   {row['team']:15s} {row['points']:6d} {title:^{TITLE_W}} {releg:^{REL_W}}"
+            f"{row['position']:>2d}   {row['team']:15s} {row['spi']:6.1f} {row['points']:6d} {title:^{TITLE_W}} {releg:^{REL_W}}"
         )
 
 

--- a/src/brasileirao/simulator.py
+++ b/src/brasileirao/simulator.py
@@ -1761,8 +1761,26 @@ def summary_table(
         logistic_decay=logistic_decay,
     )
 
+    strengths, _avg, _ha, _extra = get_strengths(
+        matches,
+        rating_method,
+        elo_k=elo_k,
+        home_field_advantage=home_field_advantage,
+        leader_history_paths=leader_history_paths,
+        leader_history_weight=leader_history_weight,
+        smooth=smooth,
+        market_path=market_path,
+        decay_rate=decay_rate,
+        logistic_decay=logistic_decay,
+    )
+    spi = {
+        t: float(30 * np.log10(max(s["attack"] / s["defense"], 1e-6)) + 75)
+        for t, s in strengths.items()
+    }
+
     table = table.sort_values("position").reset_index(drop=True)
     table["points"] = table["points"].round().astype(int)
     table["title"] = table["team"].map(chances)
     table["relegation"] = table["team"].map(relegation)
-    return table[["position", "team", "points", "title", "relegation"]]
+    table["spi"] = table["team"].map(spi)
+    return table[["position", "team", "spi", "points", "title", "relegation"]]

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -9,6 +9,7 @@ from brasileirao import (
     league_table,
     simulate_chances,
     simulate_final_table,
+    summary_table,
     estimate_spi_strengths,
     compute_spi_coeffs,
     initial_spi_strengths,
@@ -293,3 +294,16 @@ def test_compute_leader_stats_regression():
         "Ceará": 1,
     }
     assert counts == expected
+
+
+def test_summary_table_includes_spi_column():
+    df = parse_matches("data/Brasileirao2025A.txt")
+    table = summary_table(df, iterations=1)
+    assert list(table.columns) == [
+        "position",
+        "team",
+        "spi",
+        "points",
+        "title",
+        "relegation",
+    ]


### PR DESCRIPTION
## Summary
- include a new SPI rating derived from team strengths
- update main output to show SPI column
- mention SPI rating in README
- add regression test for the new summary table column

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688700d0c6588325ae685488c923565f