### PR TITLE
Adjust SPI coefficients usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ expected goal difference into win/draw/loss probabilities during the
 simulation. When no matches have been played the intercept and slope are
 automatically derived from the available seasons using ``compute_spi_coeffs``
 instead of returning the hard-coded ``-0.309255`` and ``0.425492`` defaults.
+These defaults were themselves obtained by applying ``compute_spi_coeffs`` to
+the historical results bundled in ``data/``.
 The helper ``initial_spi_strengths`` can be used at the start of a season to
 shrink each team's previous rating towards the league average following
 ``current = previous × weight + mean × (1 − weight)``.

--- a/src/brasileirao/simulator.py
+++ b/src/brasileirao/simulator.py
@@ -1255,14 +1255,22 @@ def get_strengths(
             decay_rate=decay_rate,
             logistic_decay=logistic_decay,
         )
-        if seasons is not None:
-            from .spi_coeffs import compute_spi_coeffs
+        from .spi_coeffs import compute_spi_coeffs
 
+        if seasons is None:
+            intercept, slope = compute_spi_coeffs(
+                market_path=market_path,
+                smooth=smooth,
+                decay_rate=decay_rate or 0.0,
+                logistic_decay=logistic_decay,
+            )
+        else:
             intercept, slope = compute_spi_coeffs(
                 seasons=seasons,
                 market_path=market_path,
                 smooth=smooth,
                 decay_rate=decay_rate or 0.0,
+                logistic_decay=logistic_decay,
             )
         extra_param = (intercept, slope)
     elif rating_method == "initial_spi":

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -20,6 +20,7 @@ from brasileirao.simulator import (
     update_spi_ratings,
     estimate_market_strengths,
     compute_leader_stats,
+    get_strengths,
 )
 from brasileirao.spi_coeffs import available_seasons
 
@@ -60,6 +61,18 @@ def test_estimate_spi_strengths_returns_five_values():
     assert len(result) == 5
     assert isinstance(result[-1], float)
     assert isinstance(result[-2], float)
+
+
+def test_estimate_spi_strengths_empty_uses_spi_coeffs():
+    df = parse_matches("data/Brasileirao2025A.txt")
+    df["home_score"] = np.nan
+    df["away_score"] = np.nan
+
+    result = estimate_spi_strengths(df)
+    expected = compute_spi_coeffs()
+
+    assert np.isclose(result[3], expected[0])
+    assert np.isclose(result[4], expected[1])
 
 
 def test_compute_spi_coeffs_empty_returns_defaults():
@@ -199,6 +212,15 @@ def test_initial_spi_strengths_multiple_seasons_changes_output():
     assert not np.isclose(
         single["Palmeiras"]["attack"], multi["Palmeiras"]["attack"]
     )
+
+
+def test_get_strengths_spi_defaults_to_computed_coeffs():
+    df = parse_matches("data/Brasileirao2025A.txt")
+    strengths, _avg, _ha, extra = get_strengths(df, rating_method="spi")
+    expected = compute_spi_coeffs(market_path="data/Brasileirao2025A.csv")
+
+    assert np.isclose(extra[0], expected[0])
+    assert np.isclose(extra[1], expected[1])
 
 
 def test_spi_coeffs_uses_season_market_files():


### PR DESCRIPTION
## Summary
- default to historical SPI coefficients in `get_strengths`
- document where default SPI coeffs come from
- ensure tests cover SPI coefficient selection logic

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68870afbcff08325aa2abb29b46f2be6