### PR TITLE
Add attack and defense columns to outputs

### DIFF
--- a/main.py
+++ b/main.py
@@ -164,15 +164,19 @@ def main() -> None:
         for t, s in strengths.items()
     }
     summary["spi"] = summary["team"].map(spi)
+    summary["attack"] = summary["team"].map(lambda t: strengths[t]["attack"])
+    summary["defense"] = summary["team"].map(lambda t: strengths[t]["defense"])
 
     TITLE_W = 7
     REL_W = 10
-    print(f"{'Pos':>3}  {'Team':15s} {'SPI':>6} {'Points':>6} {'Title':^{TITLE_W}} {'Relegation':^{REL_W}}")
+    print(
+        f"{'Pos':>3}  {'Team':15s} {'SPI':>6} {'Attack':>6} {'Defense':>7} {'Points':>6} {'Title':^{TITLE_W}} {'Relegation':^{REL_W}}"
+    )
     for _, row in summary.iterrows():
         title = f"{row['title']:.2%}"
         releg = f"{row['relegation']:.2%}"
         print(
-            f"{row['position']:>2d}   {row['team']:15s} {row['spi']:6.1f} {row['points']:6d} {title:^{TITLE_W}} {releg:^{REL_W}}"
+            f"{row['position']:>2d}   {row['team']:15s} {row['spi']:6.1f} {row['attack']:6.2f} {row['defense']:7.2f} {row['points']:6d} {title:^{TITLE_W}} {releg:^{REL_W}}"
         )
 
 

--- a/src/brasileirao/simulator.py
+++ b/src/brasileirao/simulator.py
@@ -1791,4 +1791,17 @@ def summary_table(
     table["title"] = table["team"].map(chances)
     table["relegation"] = table["team"].map(relegation)
     table["spi"] = table["team"].map(spi)
-    return table[["position", "team", "spi", "points", "title", "relegation"]]
+    table["attack"] = table["team"].map(lambda t: strengths[t]["attack"])
+    table["defense"] = table["team"].map(lambda t: strengths[t]["defense"])
+    return table[
+        [
+            "position",
+            "team",
+            "spi",
+            "attack",
+            "defense",
+            "points",
+            "title",
+            "relegation",
+        ]
+    ]

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -325,6 +325,8 @@ def test_summary_table_includes_spi_column():
         "position",
         "team",
         "spi",
+        "attack",
+        "defense",
         "points",
         "title",
         "relegation",


### PR DESCRIPTION
## Summary
- enrich `summary_table` with attack/defense strengths
- print attack and defense in CLI output
- test new summary table columns

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6887e90a8fe48325897cffaf64a98b91